### PR TITLE
close statement after creating schema

### DIFF
--- a/src/ch/ehi/sqlgen/DbUtility.java
+++ b/src/ch/ehi/sqlgen/DbUtility.java
@@ -210,13 +210,18 @@ public class DbUtility {
 	public static void createSchema(Connection conn,String schemaName)
 	{
 		try {
-			java.sql.Statement stmt=conn.createStatement();
-			String sql="CREATE SCHEMA "+schemaName;
-			EhiLogger.traceBackendCmd(sql);
-			stmt.execute(sql);
+			Statement stmt = null;
+			try {
+				stmt=conn.createStatement();
+				String sql="CREATE SCHEMA "+schemaName;
+				EhiLogger.traceBackendCmd(sql);
+				stmt.execute(sql);
+			} finally {
+				stmt.close();
+			}
 		} catch (SQLException e) {
 			throw new IllegalStateException("failed to create schema "+schemaName,e);
-		}
+		} 
 	}
 
 	public static void executeSqlScript(Connection conn,java.io.InputStreamReader script)


### PR DESCRIPTION
DuckDB hat einen Bug: https://github.com/duckdb/duckdb-java/issues/101 Wobei es m.E. auch in anderen Fällen passiert (der Deadlock), v.a. wenn Statements nicht geschlossen werden.